### PR TITLE
Fix compiler warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ lazy val commonSettings = Seq(
     scalaVersion := "2.12.8",
     scalafmtConfig := file(".scalafmt"),
     scalafmtOnCompile := true,
-    addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.16"),
     coverageEnabled := false,
     coverageMinimum := 70,
     coverageFailOnMinimum := false,
@@ -25,5 +24,3 @@ lazy val core = (project in file("core"))
   .settings(commonSettings: _*)
   .settings(name := "core")
   .settings(libraryDependencies ++= librarySettings)
-  .settings(scalacOptions ++= Seq("-unchecked", "-deprecation", "-Xlint"))
-  .settings(scalacOptions in Test ++= Seq("-Yrangepos", "-Xlint"))

--- a/core/src/main/scala/aima/core/agent/Action.scala
+++ b/core/src/main/scala/aima/core/agent/Action.scala
@@ -1,8 +1,0 @@
-package aima.core.agent
-
-/**
-  * @author Shawn Garner
-  */
-trait Action extends Any
-
-case object NoAction extends Action

--- a/core/src/main/scala/aima/core/agent/Actuator.scala
+++ b/core/src/main/scala/aima/core/agent/Actuator.scala
@@ -5,13 +5,15 @@ import aima.core.util.Randomness
 /**
   * @author Shawn Garner
   */
-trait Actuator {
-  def agent: Agent
-  def act(action: Action, environment: Environment): Environment
+trait Actuator[Action, Percept] {
+  def agent: Agent[Action, Percept]
+  def act(action: Action, environment: Environment[Action, Percept]): Environment[Action, Percept]
 }
 
-trait UnreliableActuator extends Actuator with Randomness {
-  def unreliably(original: Environment, reliability: Int = 50)(act: => Environment): Environment = {
+trait UnreliableActuator[Action, Percept] extends Actuator[Action, Percept] with Randomness {
+  def unreliably(original: Environment[Action, Percept], reliability: Int = 50)(
+      act: => Environment[Action, Percept]
+  ): Environment[Action, Percept] = {
     if (rand.nextInt(100) < reliability) act else original
   }
 }

--- a/core/src/main/scala/aima/core/agent/Agent.scala
+++ b/core/src/main/scala/aima/core/agent/Agent.scala
@@ -3,12 +3,12 @@ package aima.core.agent
 /**
   * @author Shawn Garner
   */
-trait AgentProgram {
-  def actuators: Seq[Actuator]
-  def sensors: Seq[Sensor]
-  def agent: Agent
+trait AgentProgram[Action, Percept] {
+  def actuators: Seq[Actuator[Action, Percept]]
+  def sensors: Seq[Sensor[Action, Percept]]
+  def agent: Agent[Action, Percept]
 
-  def run(environment: Environment): Environment = {
+  def run(environment: Environment[Action, Percept]): Environment[Action, Percept] = {
     val actions = for {
       sensor <- sensors
     } yield agent.agentFunction(sensor.perceive(environment))
@@ -21,7 +21,7 @@ trait AgentProgram {
   }
 }
 
-trait Agent {
+trait Agent[Action, Percept] {
   type AgentFunction = Percept => Action
 
   def agentFunction: AgentFunction

--- a/core/src/main/scala/aima/core/agent/Agent.scala
+++ b/core/src/main/scala/aima/core/agent/Agent.scala
@@ -4,8 +4,8 @@ package aima.core.agent
   * @author Shawn Garner
   */
 trait AgentProgram[Action, Percept] {
-  def actuators: Seq[Actuator[Action, Percept]]
-  def sensors: Seq[Sensor[Action, Percept]]
+  def actuators: List[Actuator[Action, Percept]]
+  def sensors: List[Sensor[Action, Percept]]
   def agent: Agent[Action, Percept]
 
   def run(environment: Environment[Action, Percept]): Environment[Action, Percept] = {

--- a/core/src/main/scala/aima/core/agent/Environment.scala
+++ b/core/src/main/scala/aima/core/agent/Environment.scala
@@ -3,9 +3,9 @@ package aima.core.agent
 /**
   * @author Shawn Garner
   */
-trait Environment {
-  def addAgent(agent: Agent): Environment
-  def removeAgent(agent: Agent): Environment
-  def actuate(actuator: Actuator, action: Action): Environment
-  def perceive(sensor: Sensor): Percept
+trait Environment[Action, Percept] {
+  def addAgent(agent: Agent[Action, Percept]): Environment[Action, Percept]
+  def removeAgent(agent: Agent[Action, Percept]): Environment[Action, Percept]
+  def actuate(actuator: Actuator[Action, Percept], action: Action): Environment[Action, Percept]
+  def perceive(sensor: Sensor[Action, Percept]): Percept
 }

--- a/core/src/main/scala/aima/core/agent/ModelBasedReflexAgent.scala
+++ b/core/src/main/scala/aima/core/agent/ModelBasedReflexAgent.scala
@@ -3,18 +3,18 @@ package aima.core.agent
 /**
   * @author Shawn Garner
   */
-trait ModelBasedReflexAgent extends Agent {
-  type State
-  type Model       = PartialFunction[(State, Action), State] //a description of how the next state depends on the current state and action
+trait ModelBasedReflexAgent[State, Action, Percept] extends Agent[Action, Percept] {
+  type Model       = (State, Action) => State //a description of how the next state depends on the current state and action
   type UpdateState = (State, Action, Percept, Model) => State
-  type RuleMatch   = PartialFunction[State, Action]
+  type RuleMatch   = State => Action
 
   def initialState: State
+  def noAction: Action
 
   var state: State   = initialState // the agent's current conception of the world state
-  var action: Action = NoAction     //most recent action
+  var action: Action = noAction     //most recent action
 
-  lazy val agentFunction: AgentFunction = { percept =>
+  val agentFunction: AgentFunction = { percept =>
     state = updateState(state, action, percept, model)
     action = ruleMatch(state)
     action
@@ -24,7 +24,7 @@ trait ModelBasedReflexAgent extends Agent {
   def model: Model // Figure depicts as persistent but doesn't define how to update it?
 
   def ruleMatch(state: State): Action = {
-    rules.applyOrElse(state, (_: State) => NoAction)
+    rules(state)
   }
 
   def updateState: UpdateState

--- a/core/src/main/scala/aima/core/agent/Percept.scala
+++ b/core/src/main/scala/aima/core/agent/Percept.scala
@@ -1,8 +1,0 @@
-package aima.core.agent
-
-/**
-  * @author Shawn Garner
-  */
-trait Percept extends Any
-
-case object NoPercept extends Percept

--- a/core/src/main/scala/aima/core/agent/Sensor.scala
+++ b/core/src/main/scala/aima/core/agent/Sensor.scala
@@ -2,13 +2,13 @@ package aima.core.agent
 
 import aima.core.util.Randomness
 
-trait Sensor {
-  def agent: Agent
-  def perceive(environment: Environment): Percept
+trait Sensor[Action, Percept] {
+  def agent: Agent[Action, Percept]
+  def perceive(environment: Environment[Action, Percept]): Percept
 }
 
-trait UnreliableSensor extends Sensor with Randomness {
-  def unreliably(reliability: Int = 50)(perceive: => Percept): Percept = {
-    if (rand.nextInt(100) < reliability) perceive else NoPercept
+trait UnreliableSensor[Action, Percept] extends Sensor[Action, Percept] with Randomness {
+  def unreliably(reliability: Int = 50)(perceive: => Percept)(noPercept: Percept): Percept = {
+    if (rand.nextInt(100) < reliability) perceive else noPercept
   }
 }

--- a/core/src/main/scala/aima/core/agent/SimpleProblemSolvingAgent.scala
+++ b/core/src/main/scala/aima/core/agent/SimpleProblemSolvingAgent.scala
@@ -3,12 +3,10 @@ package aima.core.agent
 /**
   * @author Shawn Garner
   */
-trait SimpleProblemSolvingAgent extends Agent {
-  type State
-  type Goal
-  type Problem
+trait SimpleProblemSolvingAgent[State, Action, Percept, Goal, Problem] extends Agent[Action, Percept] {
 
   def initialState: State
+  def noAction: Action
 
   var actions = List.empty[Action]
   var state   = initialState
@@ -22,7 +20,7 @@ trait SimpleProblemSolvingAgent extends Agent {
     }
 
     val (firstAction, restOfActions) = actions match {
-      case Nil           => (NoAction, Nil)
+      case Nil           => (noAction, Nil)
       case first :: rest => (first, rest)
     }
 

--- a/core/src/main/scala/aima/core/agent/SimpleReflexAgent.scala
+++ b/core/src/main/scala/aima/core/agent/SimpleReflexAgent.scala
@@ -8,7 +8,7 @@ trait SimpleReflexAgent[State, Action, Percept] extends Agent[Action, Percept] {
 
   type RuleMatch = State => Action
 
-  lazy val agentFunction: AgentFunction = { percept =>
+  val agentFunction: AgentFunction = { percept =>
     val state = interpretInput(percept)
     ruleMatch(state)
   }

--- a/core/src/main/scala/aima/core/agent/SimpleReflexAgent.scala
+++ b/core/src/main/scala/aima/core/agent/SimpleReflexAgent.scala
@@ -3,11 +3,10 @@ package aima.core.agent
 /**
   * @author Shawn Garner
   */
-trait SimpleReflexAgent extends Agent {
-  type State
-  type InterpretInput = PartialFunction[Percept, State]
+trait SimpleReflexAgent[State, Action, Percept] extends Agent[Action, Percept] {
+  type InterpretInput = Percept => State
 
-  type RuleMatch = PartialFunction[State, Action]
+  type RuleMatch = State => Action
 
   lazy val agentFunction: AgentFunction = { percept =>
     val state = interpretInput(percept)
@@ -17,7 +16,7 @@ trait SimpleReflexAgent extends Agent {
   def rules: RuleMatch
 
   def ruleMatch(state: State): Action = {
-    rules.applyOrElse(state, (_: State) => NoAction)
+    rules(state)
   }
 
   def interpretInput: InterpretInput

--- a/core/src/main/scala/aima/core/agent/TableDrivenAgent.scala
+++ b/core/src/main/scala/aima/core/agent/TableDrivenAgent.scala
@@ -5,18 +5,19 @@ import scala.collection.mutable
 /**
   * @author Shawn Garner
   */
-trait TableDrivenAgent extends Agent {
-  type LookupTable = PartialFunction[List[Percept], Action]
+trait TableDrivenAgent[Action, Percept] extends Agent[Action, Percept] {
+  type LookupTable = List[Percept] => Action
+
+  val percepts = new mutable.ListBuffer[Percept]()
 
   def lookupTable: LookupTable
-  lazy val percepts = new mutable.ListBuffer[Percept]()
 
-  lazy val agentFunction: AgentFunction = { percept =>
+  val agentFunction: AgentFunction = { percept =>
     percepts += percept
     lookup(lookupTable, percepts.toList)
   }
 
-  def lookup(lookup: LookupTable, percepts: List[Percept]): Action = {
-    lookup.applyOrElse(percepts, (_: List[Percept]) => NoAction)
+  def lookup(lt: LookupTable, percepts: List[Percept]): Action = {
+    lt(percepts)
   }
 }

--- a/core/src/main/scala/aima/core/environment/vacuum/ModelBasedReflexVacuumAgent.scala
+++ b/core/src/main/scala/aima/core/environment/vacuum/ModelBasedReflexVacuumAgent.scala
@@ -40,7 +40,7 @@ class ModelBasedReflexVacuumAgent extends ModelBasedReflexAgent[VacuumWorldState
     case (currentState, NoAction) => currentState
   }
 
-  val noAction: VacuumAction = NoAction
+  lazy val noAction: VacuumAction = NoAction
 
   val rules: RuleMatch = {
     case VacuumWorldState(_, _, _, batteryLife) if batteryLife < 10 => NoAction //too costly to continue
@@ -49,7 +49,7 @@ class ModelBasedReflexVacuumAgent extends ModelBasedReflexAgent[VacuumWorldState
     case VacuumWorldState(_, locationB, _, _) if locationB          => LeftMoveAction
   }
 
-  val initialState: VacuumWorldState = VacuumWorldState()
+  lazy val initialState: VacuumWorldState = VacuumWorldState()
   val updateState: UpdateState = { (s: VacuumWorldState, a: VacuumAction, p: VacuumPercept, m: Model) =>
     val s2 = m(s, a)
     p match {

--- a/core/src/main/scala/aima/core/environment/vacuum/ModelBasedReflexVacuumAgent.scala
+++ b/core/src/main/scala/aima/core/environment/vacuum/ModelBasedReflexVacuumAgent.scala
@@ -1,6 +1,6 @@
 package aima.core.environment.vacuum
 
-import aima.core.agent.{Percept, Action, NoAction, ModelBasedReflexAgent}
+import aima.core.agent.ModelBasedReflexAgent
 import ModelBasedReflexVacuumAgent._
 
 object ModelBasedReflexVacuumAgent {
@@ -8,21 +8,19 @@ object ModelBasedReflexVacuumAgent {
   val SUCK_BATTERY_COST = 1
 }
 
+final case class VacuumWorldState(
+    locationA: Boolean = false,
+    locationB: Boolean = false,
+    dirty: Boolean = true,
+    batteryLife: Int = 100
+)
+
 /**
   * @author Shawn Garner
   */
-class ModelBasedReflexVacuumAgent extends ModelBasedReflexAgent {
+class ModelBasedReflexVacuumAgent extends ModelBasedReflexAgent[VacuumWorldState, VacuumAction, VacuumPercept] {
 
-  case class VacuumWorldState(
-      locationA: Boolean = false,
-      locationB: Boolean = false,
-      dirty: Boolean = true,
-      batteryLife: Int = 100
-  )
-
-  type State = VacuumWorldState
-
-  lazy val model: Model = {
+  val model: Model = {
     case (currentState, RightMoveAction) =>
       currentState.copy(
         locationA = false,
@@ -42,16 +40,18 @@ class ModelBasedReflexVacuumAgent extends ModelBasedReflexAgent {
     case (currentState, NoAction) => currentState
   }
 
-  lazy val rules: RuleMatch = {
+  val noAction: VacuumAction = NoAction
+
+  val rules: RuleMatch = {
     case VacuumWorldState(_, _, _, batteryLife) if batteryLife < 10 => NoAction //too costly to continue
     case VacuumWorldState(_, _, dirty, _) if dirty                  => Suck
     case VacuumWorldState(locationA, _, _, _) if locationA          => RightMoveAction
     case VacuumWorldState(_, locationB, _, _) if locationB          => LeftMoveAction
   }
 
-  lazy val initialState: State = VacuumWorldState()
-  lazy val updateState: UpdateState = { (s: State, a: Action, p: Percept, m: Model) =>
-    val s2 = m.applyOrElse((s, a), (_: (State, Action)) => s)
+  val initialState: VacuumWorldState = VacuumWorldState()
+  val updateState: UpdateState = { (s: VacuumWorldState, a: VacuumAction, p: VacuumPercept, m: Model) =>
+    val s2 = m(s, a)
     p match {
       case CleanPercept     => s2.copy(dirty = false)
       case DirtyPercept     => s2.copy(dirty = true)

--- a/core/src/main/scala/aima/core/environment/vacuum/SimpleReflexVacuumAgent.scala
+++ b/core/src/main/scala/aima/core/environment/vacuum/SimpleReflexVacuumAgent.scala
@@ -1,20 +1,18 @@
 package aima.core.environment.vacuum
 
-import aima.core.agent.{Percept, SimpleReflexAgent}
+import aima.core.agent.SimpleReflexAgent
 
 /**
   * @author Shawn Garner
   */
-class SimpleReflexVacuumAgent extends SimpleReflexAgent {
-  type State = Percept
+class SimpleReflexVacuumAgent extends SimpleReflexAgent[VacuumPercept, VacuumAction, VacuumPercept] {
+  val interpretInput: InterpretInput = identity
 
-  lazy val interpretInput: InterpretInput = {
-    case s => s
-  }
-
-  lazy val rules: RuleMatch = {
+  val rules: RuleMatch = {
     case DirtyPercept     => Suck
     case LocationAPercept => RightMoveAction
     case LocationBPercept => LeftMoveAction
+    case CleanPercept     => NoAction
+    case NoPercept        => NoAction
   }
 }

--- a/core/src/main/scala/aima/core/environment/vacuum/TableDrivenVacuumAgent.scala
+++ b/core/src/main/scala/aima/core/environment/vacuum/TableDrivenVacuumAgent.scala
@@ -5,8 +5,8 @@ import aima.core.agent._
 /**
   * @author Shawn Garner
   */
-class TableDrivenVacuumAgent extends TableDrivenAgent {
-  lazy val lookupTable: LookupTable = {
+class TableDrivenVacuumAgent extends TableDrivenAgent[VacuumAction, VacuumPercept] {
+  val lookupTable: LookupTable = {
     case List(_, DirtyPercept)                                  => Suck
     case List(LocationAPercept, CleanPercept)                   => RightMoveAction
     case List(LocationBPercept, CleanPercept)                   => LeftMoveAction
@@ -19,5 +19,6 @@ class TableDrivenVacuumAgent extends TableDrivenAgent {
     case List(_, _, _, _, _, _, _, DirtyPercept)                => Suck
     case List(_, _, _, _, _, _, LocationAPercept, CleanPercept) => RightMoveAction
     case List(_, _, _, _, _, _, LocationBPercept, CleanPercept) => LeftMoveAction
+    case _                                                      => NoAction
   }
 }

--- a/core/src/main/scala/aima/core/environment/vacuum/VacuumEnvironment.scala
+++ b/core/src/main/scala/aima/core/environment/vacuum/VacuumEnvironment.scala
@@ -6,29 +6,33 @@ import aima.core.util.DefaultRandomness
 /**
   * @author Shawn Garner
   */
-case class VacuumEnvironment(map: VacuumMap = VacuumMap()) extends Environment { self =>
+case class VacuumEnvironment(map: VacuumMap = VacuumMap()) extends Environment[VacuumAction, VacuumPercept] { self =>
 
-  def addAgent(agent: Agent): Environment = {
+  def addAgent(agent: Agent[VacuumAction, VacuumPercept]): Environment[VacuumAction, VacuumPercept] = {
     VacuumEnvironment(map.addAgent(agent))
   }
 
-  def removeAgent(agent: Agent): Environment = {
+  def removeAgent(agent: Agent[VacuumAction, VacuumPercept]): Environment[VacuumAction, VacuumPercept] = {
     VacuumEnvironment(map.removeAgent(agent))
   }
 
-  def actuate(actuator: Actuator, action: Action): Environment =
+  def actuate(
+      actuator: Actuator[VacuumAction, VacuumPercept],
+      action: VacuumAction
+  ): Environment[VacuumAction, VacuumPercept] =
     (action, actuator) match {
-      case (Suck, sa: SuckerActuator) => VacuumEnvironment(map.updateStatus(sa.agent, CleanPercept))
-      case (moveAction: MoveAction, actuator: MoveActuator) =>
+      case (Suck, sa: SuckerActuator[VacuumAction, VacuumPercept]) =>
+        VacuumEnvironment(map.updateStatus(sa.agent, CleanPercept))
+      case (moveAction: MoveAction, actuator: MoveActuator[VacuumAction, VacuumPercept]) =>
         VacuumEnvironment(map.moveAgent(actuator.agent, moveAction))
       case _ => self
     }
 
-  def perceive(sensor: Sensor): Percept = sensor match {
-    case ls: AgentLocationSensor =>
+  def perceive(sensor: Sensor[VacuumAction, VacuumPercept]): VacuumPercept = sensor match {
+    case ls: AgentLocationSensor[VacuumAction, VacuumPercept] =>
       map.getAgentLocation(ls.agent).getOrElse(NoPercept)
 
-    case ds: DirtSensor =>
+    case ds: DirtSensor[VacuumAction, VacuumPercept] =>
       map.getDirtStatus(ds.agent).getOrElse(NoPercept)
   }
 
@@ -37,7 +41,10 @@ case class VacuumEnvironment(map: VacuumMap = VacuumMap()) extends Environment {
   }
 }
 
-case class VacuumMapNode(dirtStatus: DirtPercept = DirtPercept.randomValue, maybeAgent: Option[Agent] = None)
+case class VacuumMapNode(
+    dirtStatus: DirtPercept = DirtPercept.randomValue,
+    maybeAgent: Option[Agent[VacuumAction, VacuumPercept]] = None
+)
 
 case class VacuumMap(nodes: Vector[VacuumMapNode] = Vector.fill(2)(VacuumMapNode())) extends DefaultRandomness {
   self =>
@@ -51,19 +58,19 @@ case class VacuumMap(nodes: Vector[VacuumMapNode] = Vector.fill(2)(VacuumMapNode
     }
   }
 
-  def getDirtStatus(agent: Agent): Option[Percept] =
+  def getDirtStatus(agent: Agent[VacuumAction, VacuumPercept]): Option[VacuumPercept] =
     nodes.collectFirst {
       case VacuumMapNode(dirtStatus, Some(a)) if agent == a => dirtStatus
     }
 
-  def getAgentLocation(agent: Agent): Option[Percept] = {
+  def getAgentLocation(agent: Agent[VacuumAction, VacuumPercept]): Option[VacuumPercept] = {
     val maybeIndex = nodes.zipWithIndex.collectFirst {
       case (VacuumMapNode(_, Some(a)), index) if agent == a => index
     }
     maybeIndex.map(index => indexToLocationPercept(index))
   }
 
-  private[this] def indexToLocationPercept(index: Int): Percept = {
+  private[this] def indexToLocationPercept(index: Int): VacuumPercept = {
     if (index == 0) {
       LocationAPercept
     } else {
@@ -76,13 +83,15 @@ case class VacuumMap(nodes: Vector[VacuumMapNode] = Vector.fill(2)(VacuumMapNode
       case RightMoveAction => 1
     }
 
-  def moveAgent(agent: Agent, direction: MoveAction): VacuumMap = {
+  def moveAgent(agent: Agent[VacuumAction, VacuumPercept], direction: MoveAction): VacuumMap = {
     removeAgent(agent).updateByIndex(directionToMapIndex(direction))(
       vacuumMapNode => vacuumMapNode.copy(maybeAgent = Some(agent))
     )
   }
 
-  private[this] def updateByAgent(target: Agent)(f: VacuumMapNode => VacuumMapNode): VacuumMap = {
+  private[this] def updateByAgent(
+      target: Agent[VacuumAction, VacuumPercept]
+  )(f: VacuumMapNode => VacuumMapNode): VacuumMap = {
     val updatedNodes = nodes.map {
       case n @ VacuumMapNode(_, Some(a)) if a == target => f(n)
       case x                                            => x
@@ -90,10 +99,10 @@ case class VacuumMap(nodes: Vector[VacuumMapNode] = Vector.fill(2)(VacuumMapNode
     VacuumMap(updatedNodes)
   }
 
-  def updateStatus(agent: Agent, dirtStatusPercepts: DirtPercept): VacuumMap =
+  def updateStatus(agent: Agent[VacuumAction, VacuumPercept], dirtStatusPercepts: DirtPercept): VacuumMap =
     updateByAgent(agent)(vacuumMapNode => vacuumMapNode.copy(dirtStatus = dirtStatusPercepts))
 
-  def removeAgent(agent: Agent): VacuumMap =
+  def removeAgent(agent: Agent[VacuumAction, VacuumPercept]): VacuumMap =
     updateByAgent(agent)(vacuumMapNode => vacuumMapNode.copy(maybeAgent = None))
 
   private def updateByIndex(index: Int)(f: VacuumMapNode => VacuumMapNode): VacuumMap = {
@@ -102,7 +111,7 @@ case class VacuumMap(nodes: Vector[VacuumMapNode] = Vector.fill(2)(VacuumMapNode
     VacuumMap(updatedNodes)
   }
 
-  def addAgent(agent: Agent): VacuumMap = {
+  def addAgent(agent: Agent[VacuumAction, VacuumPercept]): VacuumMap = {
     if (nodes.count(_.maybeAgent.isDefined) == 0) {
       val selection = rand.nextInt(nodes.size)
       updateByIndex(selection)(vacuumMapNode => vacuumMapNode.copy(maybeAgent = Some(agent)))

--- a/core/src/main/scala/aima/core/environment/vacuum/actions.scala
+++ b/core/src/main/scala/aima/core/environment/vacuum/actions.scala
@@ -1,22 +1,25 @@
 package aima.core.environment.vacuum
 
-import aima.core.agent.Action
 import aima.core.util.{DefaultRandomness, SetRandomness}
 
 /**
   * @author Shawn Garner
   */
-sealed trait MoveAction     extends Action
+sealed trait VacuumAction
+
+sealed trait MoveAction     extends VacuumAction
 case object LeftMoveAction  extends MoveAction
 case object RightMoveAction extends MoveAction
 
 object MoveAction extends SetRandomness[MoveAction] with DefaultRandomness {
-  lazy val valueSet: Set[MoveAction] = Set(LeftMoveAction, RightMoveAction)
+  val valueSet: Set[MoveAction] = Set(LeftMoveAction, RightMoveAction)
 }
 
-sealed trait SuckerAction extends Action
+sealed trait SuckerAction extends VacuumAction
 case object Suck          extends SuckerAction
 
 object SuckerAction extends SetRandomness[SuckerAction] with DefaultRandomness {
-  lazy val valueSet: Set[SuckerAction] = Set(Suck)
+  val valueSet: Set[SuckerAction] = Set(Suck)
 }
+
+case object NoAction extends VacuumAction

--- a/core/src/main/scala/aima/core/environment/vacuum/actuators.scala
+++ b/core/src/main/scala/aima/core/environment/vacuum/actuators.scala
@@ -1,20 +1,24 @@
 package aima.core.environment.vacuum
 
-import aima.core.agent.{Environment, Action, UnreliableActuator, Agent}
+import aima.core.agent.{Environment, UnreliableActuator, Agent}
 import aima.core.util.DefaultRandomness
 
 /**
   * @author Shawn Garner
   */
-class SuckerActuator(val agent: Agent) extends UnreliableActuator with DefaultRandomness { self =>
-  def act(action: Action, environment: Environment): Environment = {
+class SuckerActuator[Action, Percept](val agent: Agent[Action, Percept])
+    extends UnreliableActuator[Action, Percept]
+    with DefaultRandomness { self =>
+  def act(action: Action, environment: Environment[Action, Percept]): Environment[Action, Percept] = {
     unreliably(environment) {
       environment.actuate(self, action)
     }
   }
 }
-class MoveActuator(val agent: Agent) extends UnreliableActuator with DefaultRandomness { self =>
-  def act(action: Action, environment: Environment): Environment = {
+class MoveActuator[Action, Percept](val agent: Agent[Action, Percept])
+    extends UnreliableActuator[Action, Percept]
+    with DefaultRandomness { self =>
+  def act(action: Action, environment: Environment[Action, Percept]): Environment[Action, Percept] = {
     unreliably(environment) {
       environment.actuate(self, action)
     }

--- a/core/src/main/scala/aima/core/environment/vacuum/percepts.scala
+++ b/core/src/main/scala/aima/core/environment/vacuum/percepts.scala
@@ -1,12 +1,13 @@
 package aima.core.environment.vacuum
 
-import aima.core.agent.Percept
 import aima.core.util.{DefaultRandomness, SetRandomness}
 
 /**
   * @author Shawn Garner
   */
-sealed trait LocationPercept extends Percept
+sealed trait VacuumPercept
+
+sealed trait LocationPercept extends VacuumPercept
 case object LocationAPercept extends LocationPercept
 case object LocationBPercept extends LocationPercept
 
@@ -14,10 +15,12 @@ object LocationPercept extends SetRandomness[LocationPercept] with DefaultRandom
   lazy val valueSet: Set[LocationPercept] = Set(LocationAPercept, LocationBPercept)
 }
 
-sealed trait DirtPercept extends Percept
+sealed trait DirtPercept extends VacuumPercept
 case object CleanPercept extends DirtPercept
 case object DirtyPercept extends DirtPercept
 
 object DirtPercept extends SetRandomness[DirtPercept] with DefaultRandomness {
   lazy val valueSet: Set[DirtPercept] = Set(CleanPercept, DirtyPercept)
 }
+
+case object NoPercept extends VacuumPercept

--- a/core/src/main/scala/aima/core/environment/vacuum/sensors.scala
+++ b/core/src/main/scala/aima/core/environment/vacuum/sensors.scala
@@ -1,19 +1,25 @@
 package aima.core.environment.vacuum
 
-import aima.core.agent.{Percept, Environment, UnreliableSensor, Agent}
+import aima.core.agent.{Environment, UnreliableSensor, Agent}
 import aima.core.util.DefaultRandomness
 
 /**
   * @author Shawn Garner
   */
-class AgentLocationSensor(val agent: Agent) extends UnreliableSensor with DefaultRandomness { self =>
-  def perceive(environment: Environment): Percept = unreliably() {
-    environment.perceive(self)
-  }
+class AgentLocationSensor[Action, Percept](val agent: Agent[Action, Percept], noPercept: Percept)
+    extends UnreliableSensor[Action, Percept]
+    with DefaultRandomness { self =>
+  def perceive(environment: Environment[Action, Percept]): Percept =
+    unreliably() {
+      environment.perceive(self)
+    }(noPercept)
 }
 
-class DirtSensor(val agent: Agent) extends UnreliableSensor with DefaultRandomness { self =>
-  def perceive(environment: Environment): Percept = unreliably() {
-    environment.perceive(self)
-  }
+class DirtSensor[Action, Percept](val agent: Agent[Action, Percept], noPercept: Percept)
+    extends UnreliableSensor[Action, Percept]
+    with DefaultRandomness { self =>
+  def perceive(environment: Environment[Action, Percept]): Percept =
+    unreliably() {
+      environment.perceive(self)
+    }(noPercept)
 }

--- a/core/src/main/scala/aima/core/search/FrontierSearch.scala
+++ b/core/src/main/scala/aima/core/search/FrontierSearch.scala
@@ -2,17 +2,15 @@ package aima.core.search
 
 import scala.collection.immutable.Iterable
 
-trait Frontier[Node <: SearchNode] {
-  def replaceByState(childNode: Node): Frontier[Node]
+trait Frontier[State, Action, Node <: SearchNode[State, Action]] {
+  def replaceByState(childNode: Node): Frontier[State, Action, Node]
   def getNode(state: State): Option[Node]
-  def removeLeaf: Option[(Node, Frontier[Node])]
-  def add(node: Node): Frontier[Node]
-  def addAll(iterable: Iterable[Node]): Frontier[Node]
+  def removeLeaf: Option[(Node, Frontier[State, Action, Node])]
+  def add(node: Node): Frontier[State, Action, Node]
+  def addAll(iterable: Iterable[Node]): Frontier[State, Action, Node]
   def contains(state: State): Boolean
 }
 
-trait FrontierSearch {
-  type Node <: SearchNode
-
-  def newFrontier(state: State): Frontier[Node]
+trait FrontierSearch[State, Action, Node <: SearchNode[State, Action]] {
+  def newFrontier(state: State): Frontier[State, Action, Node]
 }

--- a/core/src/main/scala/aima/core/search/FrontierSearch.scala
+++ b/core/src/main/scala/aima/core/search/FrontierSearch.scala
@@ -12,5 +12,5 @@ trait Frontier[State, Action, Node <: SearchNode[State, Action]] {
 }
 
 trait FrontierSearch[State, Action, Node <: SearchNode[State, Action]] {
-  def newFrontier(state: State): Frontier[State, Action, Node]
+  def newFrontier(state: State, noAction: Action): Frontier[State, Action, Node]
 }

--- a/core/src/main/scala/aima/core/search/ProblemSearch.scala
+++ b/core/src/main/scala/aima/core/search/ProblemSearch.scala
@@ -1,6 +1,7 @@
 package aima.core.search
 
 import scala.annotation.tailrec
+import scala.reflect.ClassTag
 
 trait Problem[State, Action] {
   def initialState: State
@@ -16,11 +17,18 @@ sealed trait SearchNode[State, Action] {
   def parent: Option[SearchNode[State, Action]]
 }
 
-case class StateNode[State, Action](state: State, action: Action, parent: Option[StateNode[State, Action]])
-    extends SearchNode[State, Action]
-case class CostNode[State, Action](state: State, cost: Int, action: Action, parent: Option[CostNode[State, Action]])
-    extends SearchNode[State, Action]
-case class HeuristicsNode[State, Action](
+final case class StateNode[State, Action](
+    state: State,
+    action: Action,
+    parent: Option[StateNode[State, Action]]
+) extends SearchNode[State, Action]
+final case class CostNode[State, Action](
+    state: State,
+    cost: Int,
+    action: Action,
+    parent: Option[CostNode[State, Action]]
+) extends SearchNode[State, Action]
+final case class HeuristicsNode[State, Action](
     state: State,
     gValue: Double,
     hValue: Option[Double],
@@ -33,14 +41,15 @@ case class HeuristicsNode[State, Action](
   * @author Shawn Garner
   */
 trait ProblemSearch[State, Action, Node <: SearchNode[State, Action]] {
+  implicit val nCT: ClassTag[Node]
 
   def newChildNode(problem: Problem[State, Action], parent: Node, action: Action): Node
 
   def solution(node: Node): List[Action] = {
     @tailrec def solutionHelper(n: Node, actions: List[Action]): List[Action] = {
       n.parent match {
-        case None         => actions
-        case Some(parent) => solutionHelper(parent, n.action :: actions)
+        case None               => actions
+        case Some(parent: Node) => solutionHelper(parent, n.action :: actions)
       }
     }
 

--- a/core/src/main/scala/aima/core/search/ProblemSearch.scala
+++ b/core/src/main/scala/aima/core/search/ProblemSearch.scala
@@ -1,11 +1,8 @@
 package aima.core.search
 
-import aima.core.agent.Action
-
 import scala.annotation.tailrec
-import scala.collection.immutable.Iterable
 
-trait Problem {
+trait Problem[State, Action] {
   def initialState: State
   def isGoalState(state: State): Boolean
   def actions(state: State): List[Action]
@@ -13,36 +10,34 @@ trait Problem {
   def stepCost(state: State, action: Action, childPrime: State): Int
 }
 
-trait State
-
-sealed trait SearchNode {
+sealed trait SearchNode[State, Action] {
   def state: State
   def action: Action
-  def parent: Option[SearchNode]
+  def parent: Option[SearchNode[State, Action]]
 }
 
-case class StateNode(state: State, action: Action, parent: Option[StateNode])          extends SearchNode
-case class CostNode(state: State, cost: Int, action: Action, parent: Option[CostNode]) extends SearchNode
-case class HeuristicsNode(
+case class StateNode[State, Action](state: State, action: Action, parent: Option[StateNode[State, Action]])
+    extends SearchNode[State, Action]
+case class CostNode[State, Action](state: State, cost: Int, action: Action, parent: Option[CostNode[State, Action]])
+    extends SearchNode[State, Action]
+case class HeuristicsNode[State, Action](
     state: State,
     gValue: Double,
     hValue: Option[Double],
     fValue: Option[Double],
     action: Action,
-    parent: Option[CostNode]
-) extends SearchNode
+    parent: Option[CostNode[State, Action]]
+) extends SearchNode[State, Action]
 
 /**
   * @author Shawn Garner
   */
-trait ProblemSearch {
+trait ProblemSearch[State, Action, Node <: SearchNode[State, Action]] {
 
-  type Node <: SearchNode
-
-  def newChildNode(problem: Problem, parent: Node, action: Action): Node
+  def newChildNode(problem: Problem[State, Action], parent: Node, action: Action): Node
 
   def solution(node: Node): List[Action] = {
-    @tailrec def solutionHelper(n: SearchNode, actions: List[Action]): List[Action] = {
+    @tailrec def solutionHelper(n: Node, actions: List[Action]): List[Action] = {
       n.parent match {
         case None         => actions
         case Some(parent) => solutionHelper(parent, n.action :: actions)

--- a/core/src/main/scala/aima/core/search/adversarial/Game.scala
+++ b/core/src/main/scala/aima/core/search/adversarial/Game.scala
@@ -1,7 +1,5 @@
 package aima.core.search.adversarial
 
-import aima.core.agent.Action
-
 final case class UtilityValue(value: Double) extends AnyVal
 
 /**

--- a/core/src/main/scala/aima/core/search/contingency/AndOrGraphSearch.scala
+++ b/core/src/main/scala/aima/core/search/contingency/AndOrGraphSearch.scala
@@ -1,6 +1,7 @@
 package aima.core.search.contingency
 
 import scala.annotation.tailrec
+import scala.reflect.ClassTag
 
 /**
   *
@@ -32,6 +33,8 @@ import scala.annotation.tailrec
   * @author Shawn Garner
   */
 trait AndOrGraphSearch[ACTION, STATE] {
+  implicit val aCT: ClassTag[ACTION]
+  implicit val sCT: ClassTag[STATE]
   def andOrGraphSearch(problem: NondeterministicProblem[ACTION, STATE]): ConditionPlanResult =
     orSearch(problem.initialState(), problem, Nil)
 
@@ -92,8 +95,8 @@ trait AndOrGraphSearch[ACTION, STATE] {
 }
 
 sealed trait Step
-final case class ActionStep[ACTION](action: ACTION)                                extends Step
-final case class ConditionedSubPlan[STATE](state: STATE, subPlan: ConditionalPlan) extends Step
+final case class ActionStep[ACTION: ClassTag](action: ACTION)                                extends Step
+final case class ConditionedSubPlan[STATE: ClassTag](state: STATE, subPlan: ConditionalPlan) extends Step
 
 sealed trait ConditionPlanResult
 case object ConditionalPlanningFailure              extends ConditionPlanResult
@@ -101,7 +104,7 @@ final case class ConditionalPlan(steps: List[Step]) extends ConditionPlanResult
 
 object ConditionalPlan {
   val emptyPlan = ConditionalPlan(List.empty)
-  def show[STATE, ACTION](
+  def show[STATE: ClassTag, ACTION: ClassTag](
       conditionalPlan: ConditionalPlan,
       showState: STATE => String,
       showAction: ACTION => String

--- a/core/src/main/scala/aima/core/search/informed/RecursiveBestFirstSearch.scala
+++ b/core/src/main/scala/aima/core/search/informed/RecursiveBestFirstSearch.scala
@@ -40,7 +40,7 @@ trait RecursiveBestFirstSearch extends ProblemSearch {
           @tailrec def getBestFValue(updatedSuccessors: List[HeuristicsNode]): RBFSearchResult = {
             val sortedSuccessors = updatedSuccessors.sortBy(_.fValue.getOrElse(Double.MaxValue))
             sortedSuccessors match {
-              case HeuristicsNode(_, _, _, Some(fValue), _, _) :: rest if fValue > fLimit => SearchFailure(fValue)
+              case HeuristicsNode(_, _, _, Some(fValue), _, _) :: _ if fValue > fLimit => SearchFailure(fValue)
               case best :: (second @ HeuristicsNode(_, _, _, Some(fValue), _, _)) :: rest =>
                 val result = rbfs(best, math.min(fLimit, fValue))
                 result match {

--- a/core/src/main/scala/aima/core/search/informed/RecursiveBestFirstSearch.scala
+++ b/core/src/main/scala/aima/core/search/informed/RecursiveBestFirstSearch.scala
@@ -1,25 +1,25 @@
 package aima.core.search.informed
 
-import aima.core.agent.{NoAction, Action}
-import aima.core.search.{HeuristicsNode, State, ProblemSearch, Problem}
+import aima.core.search.{HeuristicsNode, Problem, ProblemSearch}
 
 import scala.annotation.tailrec
+import scala.reflect.ClassTag
 
 sealed trait RBFSearchResult
-final case class Solution(actions: List[Action])     extends RBFSearchResult
-final case class SearchFailure(updatedFCost: Double) extends RBFSearchResult
+final case class Solution[Action](actions: List[Action]) extends RBFSearchResult
+final case class SearchFailure(updatedFCost: Double)     extends RBFSearchResult
 
 /**
   * @author Shawn Garner
   */
-trait RecursiveBestFirstSearch extends ProblemSearch {
+trait RecursiveBestFirstSearch[State, Action] extends ProblemSearch[State, Action, HeuristicsNode[State, Action]] {
+  implicit val sCT: ClassTag[State]
+  implicit val aCT: ClassTag[Action]
 
-  type Node      = HeuristicsNode
+  type Node      = HeuristicsNode[State, Action]
   type Heuristic = Node => Double
 
-  def h: Heuristic
-
-  def search(problem: Problem): RBFSearchResult = {
+  def search(problem: Problem[State, Action], noAction: Action, h: Heuristic): RBFSearchResult = {
     def rbfs(node: Node, fLimit: Double): RBFSearchResult = {
       if (problem.isGoalState(node.state))
         Solution(solution(node))
@@ -37,14 +37,14 @@ trait RecursiveBestFirstSearch extends ProblemSearch {
               s.copy(fValue = updatedFValue)
           }
 
-          @tailrec def getBestFValue(updatedSuccessors: List[HeuristicsNode]): RBFSearchResult = {
+          @tailrec def getBestFValue(updatedSuccessors: List[Node]): RBFSearchResult = {
             val sortedSuccessors = updatedSuccessors.sortBy(_.fValue.getOrElse(Double.MaxValue))
             sortedSuccessors match {
               case HeuristicsNode(_, _, _, Some(fValue), _, _) :: _ if fValue > fLimit => SearchFailure(fValue)
               case best :: (second @ HeuristicsNode(_, _, _, Some(fValue), _, _)) :: rest =>
                 val result = rbfs(best, math.min(fLimit, fValue))
                 result match {
-                  case s: Solution => s
+                  case s: Solution[Action] => s
                   case SearchFailure(updatedFValue) =>
                     getBestFValue(best.copy(fValue = Some(updatedFValue)) :: second :: rest)
                 }
@@ -56,11 +56,11 @@ trait RecursiveBestFirstSearch extends ProblemSearch {
       }
     }
 
-    rbfs(makeNode(problem.initialState), Double.PositiveInfinity)
+    rbfs(makeNode(problem.initialState, noAction, h), Double.PositiveInfinity)
   }
 
-  def makeNode(state: State): Node = {
-    val basic          = HeuristicsNode(state = state, gValue = 0, hValue = None, fValue = None, NoAction, None)
+  def makeNode(state: State, noAction: Action, h: Heuristic): Node = {
+    val basic          = HeuristicsNode(state = state, gValue = 0, hValue = None, fValue = None, noAction, None)
     val hValue: Double = h(basic)
     val fValue: Double = basic.gValue + hValue
     basic.copy(hValue = Some(hValue), fValue = Some(fValue))

--- a/core/src/main/scala/aima/core/search/local/HillClimbing.scala
+++ b/core/src/main/scala/aima/core/search/local/HillClimbing.scala
@@ -1,6 +1,6 @@
 package aima.core.search.local
 
-import aima.core.search.{Problem, State}
+import aima.core.search.Problem
 
 import scala.annotation.tailrec
 
@@ -21,13 +21,13 @@ import scala.annotation.tailrec
   */
 object HillClimbing {
 
-  final case class StateValueNode(state: State, value: Double)
+  final case class StateValueNode[State](state: State, value: Double)
 
-  def apply(stateToValue: State => Double)(problem: Problem): State = {
+  def apply[State, Action](stateToValue: State => Double)(problem: Problem[State, Action]): State = {
 
     def makeNode(state: State) = StateValueNode(state, stateToValue(state))
 
-    def highestValuedSuccessor(current: StateValueNode): StateValueNode = {
+    def highestValuedSuccessor(current: StateValueNode[State]): StateValueNode[State] = {
       val successors = problem.actions(current.state).map(a => problem.result(current.state, a)).map(makeNode)
 
       if (successors.isEmpty) {
@@ -38,7 +38,7 @@ object HillClimbing {
 
     }
 
-    @tailrec def recurse(current: StateValueNode): State = {
+    @tailrec def recurse(current: StateValueNode[State]): State = {
       val neighbor = highestValuedSuccessor(current)
       if (neighbor.value <= current.value) {
         current.state

--- a/core/src/main/scala/aima/core/search/local/HillClimbing.scala
+++ b/core/src/main/scala/aima/core/search/local/HillClimbing.scala
@@ -1,7 +1,6 @@
 package aima.core.search.local
 
-import aima.core.agent.Action
-import aima.core.search.{Problem, ProblemSearch, State, StateNode}
+import aima.core.search.{Problem, State}
 
 import scala.annotation.tailrec
 

--- a/core/src/main/scala/aima/core/search/local/SimulatedAnnealingSearch.scala
+++ b/core/src/main/scala/aima/core/search/local/SimulatedAnnealingSearch.scala
@@ -1,7 +1,7 @@
 package aima.core.search.local
 
 import aima.core.search.local.time.TimeStep
-import aima.core.search.{Problem, State}
+import aima.core.search.Problem
 
 import scala.annotation.tailrec
 import scala.util.{Failure, Random, Success, Try}
@@ -72,17 +72,21 @@ object SimulatedAnnealingSearch {
     }
   }
 
-  final case class StateValueNode(state: State, value: Double)
+  final case class StateValueNode[State](state: State, value: Double)
 
-  def apply(stateToValue: State => Double, problem: Problem): Try[State] =
+  def apply[State, Action](stateToValue: State => Double, problem: Problem[State, Action]): Try[State] =
     apply(stateToValue, problem, BasicSchedule.schedule())
 
-  def apply(stateToValue: State => Double, problem: Problem, schedule: Schedule): Try[State] = {
+  def apply[State, Action](
+      stateToValue: State => Double,
+      problem: Problem[State, Action],
+      schedule: Schedule
+  ): Try[State] = {
     val random = new Random()
 
-    def makeNode(state: State): StateValueNode = StateValueNode(state, stateToValue(state))
+    def makeNode(state: State): StateValueNode[State] = StateValueNode(state, stateToValue(state))
 
-    def randomlySelectSuccessor(current: StateValueNode): StateValueNode = {
+    def randomlySelectSuccessor(current: StateValueNode[State]): StateValueNode[State] = {
       // Default successor to current, so that in the case we reach a dead-end
       // state i.e. one without reversible actions we will return something.
       // This will not break the code above as the loop will exit when the
@@ -99,7 +103,7 @@ object SimulatedAnnealingSearch {
       successor
     }
 
-    @tailrec def recurse(current: StateValueNode, t: Try[TimeStep]): Try[StateValueNode] = {
+    @tailrec def recurse(current: StateValueNode[State], t: Try[TimeStep]): Try[StateValueNode[State]] = {
       import time.TimeStep.Implicits._
       t match {
         case Failure(f) => Failure(f)

--- a/core/src/main/scala/aima/core/search/problems/romania.scala
+++ b/core/src/main/scala/aima/core/search/problems/romania.scala
@@ -1,7 +1,6 @@
 package aima.core.search.problems
 
-import aima.core.agent.Action
-import aima.core.search.{State, Problem}
+import aima.core.search.Problem
 
 /**
   * @author Shawn Garner
@@ -84,33 +83,35 @@ object Romania {
     acc.updated(from, road :: listForEdge)
   }
 
-  sealed trait RomaniaState extends State
+  sealed trait RomaniaState
   case class In(city: City) extends RomaniaState
 
-  sealed trait RomaniaAction  extends Action
+  sealed trait RomaniaAction
   case class GoTo(city: City) extends RomaniaAction
 
-  class RomaniaRoadProblem(val initialState: RomaniaState, val goalState: RomaniaState) extends Problem {
-    def result(currentState: State, action: Action): State = action match {
+  class RomaniaRoadProblem(val initialState: RomaniaState, val goalState: RomaniaState)
+      extends Problem[RomaniaState, RomaniaAction] {
+    def result(currentState: RomaniaState, action: RomaniaAction): RomaniaState = action match {
       case GoTo(city) => In(city)
     }
 
-    def actions(state: State): List[Action] = state match {
+    def actions(state: RomaniaState): List[RomaniaAction] = state match {
       case In(city) => roadsFromCity(city).map(road => GoTo(road.to))
     }
 
-    def isGoalState(state: State): Boolean = (state, goalState) match {
+    def isGoalState(state: RomaniaState): Boolean = (state, goalState) match {
       case (In(city), In(goal)) => city == goal
       case _                    => false
     }
 
-    def stepCost(state: State, action: Action, statePrime: State): Int = (state, statePrime) match {
-      case (In(city), In(cityPrime)) =>
-        val maybeCost = roadsFromCity(city) collectFirst {
-          case Road(c1, c2, cost) if c1 == city && c2 == cityPrime => cost
-        }
-        maybeCost.getOrElse(Int.MaxValue)
-    }
+    def stepCost(state: RomaniaState, action: RomaniaAction, statePrime: RomaniaState): Int =
+      (state, statePrime) match {
+        case (In(city), In(cityPrime)) =>
+          val maybeCost = roadsFromCity(city) collectFirst {
+            case Road(c1, c2, cost) if c1 == city && c2 == cityPrime => cost
+          }
+          maybeCost.getOrElse(Int.MaxValue)
+      }
   }
 
 }

--- a/core/src/main/scala/aima/core/search/problems/romania.scala
+++ b/core/src/main/scala/aima/core/search/problems/romania.scala
@@ -84,15 +84,17 @@ object Romania {
   }
 
   sealed trait RomaniaState
-  case class In(city: City) extends RomaniaState
+  final case class In(city: City) extends RomaniaState
 
   sealed trait RomaniaAction
-  case class GoTo(city: City) extends RomaniaAction
+  final case class GoTo(city: City) extends RomaniaAction
+  case object NoAction              extends RomaniaAction
 
   class RomaniaRoadProblem(val initialState: RomaniaState, val goalState: RomaniaState)
       extends Problem[RomaniaState, RomaniaAction] {
     def result(currentState: RomaniaState, action: RomaniaAction): RomaniaState = action match {
       case GoTo(city) => In(city)
+      case NoAction   => currentState
     }
 
     def actions(state: RomaniaState): List[RomaniaAction] = state match {

--- a/core/src/main/scala/aima/core/search/problems/romania.scala
+++ b/core/src/main/scala/aima/core/search/problems/romania.scala
@@ -1,6 +1,8 @@
 package aima.core.search.problems
 
-import aima.core.search.Problem
+import aima.core.search.{CostNode, Problem, StateNode}
+
+import scala.reflect.{ClassTag, classTag}
 
 /**
   * @author Shawn Garner
@@ -89,6 +91,14 @@ object Romania {
   sealed trait RomaniaAction
   final case class GoTo(city: City) extends RomaniaAction
   case object NoAction              extends RomaniaAction
+
+  val sCTag: ClassTag[RomaniaState]  = classTag[RomaniaState]
+  val aCTag: ClassTag[RomaniaAction] = classTag[RomaniaAction]
+
+  val snCTag: ClassTag[StateNode[RomaniaState, RomaniaAction]] =
+    classTag[StateNode[RomaniaState, RomaniaAction]]
+
+  val cnCTag: ClassTag[CostNode[RomaniaState, RomaniaAction]] = classTag[CostNode[RomaniaState, RomaniaAction]]
 
   class RomaniaRoadProblem(val initialState: RomaniaState, val goalState: RomaniaState)
       extends Problem[RomaniaState, RomaniaAction] {

--- a/core/src/main/scala/aima/core/search/uninformed/BreadthFirstSearch.scala
+++ b/core/src/main/scala/aima/core/search/uninformed/BreadthFirstSearch.scala
@@ -1,11 +1,10 @@
 package aima.core.search.uninformed
 
-import aima.core.agent.NoAction
 import aima.core.search._
 
 /**
   * @author Shawn Garner
   */
-trait BreadthFirstSearch extends GraphSearch { self =>
-  def newFrontier(state: State) = new FIFOQueueFrontier(StateNode(state, NoAction, None))
+trait BreadthFirstSearch[State, Action] extends GraphSearch[State, Action] { self =>
+  def newFrontier(state: State, noAction: Action) = new FIFOQueueFrontier(StateNode(state, noAction, None))
 }

--- a/core/src/main/scala/aima/core/search/uninformed/DepthLimitedTreeSearch.scala
+++ b/core/src/main/scala/aima/core/search/uninformed/DepthLimitedTreeSearch.scala
@@ -40,7 +40,7 @@ trait DepthLimitedTreeSearch extends ProblemSearch {
                   recursiveDLS(lastChild, currentLimit - 1)
                 case firstChild :: rest =>
                   recursiveDLS(firstChild, currentLimit - 1) match {
-                    case result @ Success(s: Solution) => result
+                    case result @ Success(Solution(_)) => result
                     case _                             => shortCircuitChildSearch(rest)
                   }
               }

--- a/core/src/main/scala/aima/core/search/uninformed/DepthLimitedTreeSearch.scala
+++ b/core/src/main/scala/aima/core/search/uninformed/DepthLimitedTreeSearch.scala
@@ -3,7 +3,6 @@ package aima.core.search.uninformed
 import aima.core.search.{Problem, ProblemSearch, StateNode}
 
 import scala.annotation.tailrec
-import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 
 sealed trait DLSResult[Action] {
@@ -17,8 +16,6 @@ final case class CutOff[Action](actions: List[Action])   extends DLSResult[Actio
   * @author Shawn Garner
   */
 trait DepthLimitedTreeSearch[State, Action] extends ProblemSearch[State, Action, StateNode[State, Action]] {
-  implicit val sCT: ClassTag[State]
-  implicit val aCT: ClassTag[Action]
 
   type Node = StateNode[State, Action]
 

--- a/core/src/main/scala/aima/core/search/uninformed/DepthLimitedTreeSearch.scala
+++ b/core/src/main/scala/aima/core/search/uninformed/DepthLimitedTreeSearch.scala
@@ -1,28 +1,31 @@
 package aima.core.search.uninformed
 
-import aima.core.agent.{NoAction, Action}
-import aima.core.search.{StateNode, State, Problem, ProblemSearch}
+import aima.core.search.{Problem, ProblemSearch, StateNode}
 
 import scala.annotation.tailrec
-import scala.util.{Success, Failure, Try}
+import scala.reflect.ClassTag
+import scala.util.{Failure, Success, Try}
 
-sealed trait DLSResult {
+sealed trait DLSResult[Action] {
   def actions: List[Action]
 }
 
-final case class Solution(actions: List[Action]) extends DLSResult
-final case class CutOff(actions: List[Action])   extends DLSResult
+final case class Solution[Action](actions: List[Action]) extends DLSResult[Action]
+final case class CutOff[Action](actions: List[Action])   extends DLSResult[Action]
 
 /**
   * @author Shawn Garner
   */
-trait DepthLimitedTreeSearch extends ProblemSearch {
-  type Node = StateNode
+trait DepthLimitedTreeSearch[State, Action] extends ProblemSearch[State, Action, StateNode[State, Action]] {
+  implicit val sCT: ClassTag[State]
+  implicit val aCT: ClassTag[Action]
 
-  def search(problem: Problem, initialLimit: Int): Try[DLSResult] =
+  type Node = StateNode[State, Action]
+
+  def search(problem: Problem[State, Action], initialLimit: Int, noAction: Action): Try[DLSResult[Action]] =
     Try {
 
-      def recursiveDLS(node: Node, currentLimit: Int): Try[DLSResult] =
+      def recursiveDLS(node: Node, currentLimit: Int): Try[DLSResult[Action]] =
         Try {
           if (problem.isGoalState(node.state)) {
             Success(Solution(solution(node)))
@@ -33,9 +36,9 @@ trait DepthLimitedTreeSearch extends ProblemSearch {
               action <- problem.actions(node.state)
             } yield newChildNode(problem, node, action)
 
-            @tailrec def shortCircuitChildSearch(children: List[Node]): Try[DLSResult] = {
+            @tailrec def shortCircuitChildSearch(children: List[Node]): Try[DLSResult[Action]] = {
               children match {
-                case Nil => Failure[DLSResult](new Exception("Exhausted child nodes"))
+                case Nil => Failure[DLSResult[Action]](new Exception("Exhausted child nodes"))
                 case lastChild :: Nil =>
                   recursiveDLS(lastChild, currentLimit - 1)
                 case firstChild :: rest =>
@@ -50,12 +53,12 @@ trait DepthLimitedTreeSearch extends ProblemSearch {
           }
         }.flatten
 
-      recursiveDLS(makeNode(problem.initialState), initialLimit)
+      recursiveDLS(makeNode(problem.initialState, noAction), initialLimit)
     }.flatten
 
-  def makeNode(state: State): Node = StateNode(state, NoAction, None)
+  def makeNode(state: State, noAction: Action): Node = StateNode(state, noAction, None)
 
-  def newChildNode(problem: Problem, parent: Node, action: Action): Node = {
+  def newChildNode(problem: Problem[State, Action], parent: Node, action: Action): Node = {
     val childState = problem.result(parent.state, action)
     StateNode(childState, action, Some(parent))
   }

--- a/core/src/main/scala/aima/core/search/uninformed/GraphSearch.scala
+++ b/core/src/main/scala/aima/core/search/uninformed/GraphSearch.scala
@@ -3,6 +3,7 @@ package aima.core.search.uninformed
 import aima.core.search._
 
 import scala.annotation.tailrec
+import scala.reflect.ClassTag
 
 /**
   * @author Shawn Garner
@@ -10,9 +11,13 @@ import scala.annotation.tailrec
 trait GraphSearch[State, Action]
     extends ProblemSearch[State, Action, StateNode[State, Action]]
     with FrontierSearch[State, Action, StateNode[State, Action]] {
+  implicit val sCT: ClassTag[State]
+  implicit val aCT: ClassTag[Action]
+
   type Node = StateNode[State, Action]
-  def search(problem: Problem[State, Action]): List[Action] = {
-    val initialFrontier = newFrontier(problem.initialState)
+
+  def search(problem: Problem[State, Action], noAction: Action): List[Action] = {
+    val initialFrontier = newFrontier(problem.initialState, noAction)
 
     @tailrec def searchHelper(
         frontier: Frontier[State, Action, Node],

--- a/core/src/main/scala/aima/core/search/uninformed/GraphSearch.scala
+++ b/core/src/main/scala/aima/core/search/uninformed/GraphSearch.scala
@@ -1,6 +1,5 @@
 package aima.core.search.uninformed
 
-import aima.core.agent.Action
 import aima.core.search._
 
 import scala.annotation.tailrec
@@ -8,12 +7,17 @@ import scala.annotation.tailrec
 /**
   * @author Shawn Garner
   */
-trait GraphSearch extends ProblemSearch with FrontierSearch {
-  type Node = StateNode
-  def search(problem: Problem): List[Action] = {
+trait GraphSearch[State, Action]
+    extends ProblemSearch[State, Action, StateNode[State, Action]]
+    with FrontierSearch[State, Action, StateNode[State, Action]] {
+  type Node = StateNode[State, Action]
+  def search(problem: Problem[State, Action]): List[Action] = {
     val initialFrontier = newFrontier(problem.initialState)
 
-    @tailrec def searchHelper(frontier: Frontier[Node], exploredSet: Set[State] = Set.empty[State]): List[Action] = {
+    @tailrec def searchHelper(
+        frontier: Frontier[State, Action, Node],
+        exploredSet: Set[State] = Set.empty[State]
+    ): List[Action] = {
       frontier.removeLeaf match {
         case None                                               => List.empty[Action]
         case Some((leaf, _)) if problem.isGoalState(leaf.state) => solution(leaf)
@@ -35,7 +39,7 @@ trait GraphSearch extends ProblemSearch with FrontierSearch {
     searchHelper(initialFrontier)
   }
 
-  def newChildNode(problem: Problem, parent: Node, action: Action): Node = {
+  def newChildNode(problem: Problem[State, Action], parent: Node, action: Action): Node = {
     val childState = problem.result(parent.state, action)
     StateNode(childState, action, Some(parent))
   }

--- a/core/src/main/scala/aima/core/search/uninformed/IterativeDeepeningSearch.scala
+++ b/core/src/main/scala/aima/core/search/uninformed/IterativeDeepeningSearch.scala
@@ -1,6 +1,6 @@
 package aima.core.search.uninformed
 
-import aima.core.search.{Problem, ProblemSearch}
+import aima.core.search.Problem
 
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}

--- a/core/src/main/scala/aima/core/search/uninformed/IterativeDeepeningSearch.scala
+++ b/core/src/main/scala/aima/core/search/uninformed/IterativeDeepeningSearch.scala
@@ -8,17 +8,18 @@ import scala.util.{Failure, Success, Try}
 /**
   * @author Shawn Garner
   */
-trait IterativeDeepeningSearch {
-  def depthLimitedTreeSearch: DepthLimitedTreeSearch
+trait IterativeDeepeningSearch[State, Action] {
+  def depthLimitedTreeSearch: DepthLimitedTreeSearch[State, Action]
 
-  def search(problem: Problem): Try[DLSResult] = {
-    @tailrec def searchHelper(currentDepth: Int): Try[DLSResult] = {
-      val result = depthLimitedTreeSearch.search(problem, currentDepth)
+  def search(problem: Problem[State, Action], noAction: Action): Try[DLSResult[Action]] = {
+    @tailrec def searchHelper(currentDepth: Int): Try[DLSResult[Action]] = {
+      val result = depthLimitedTreeSearch.search(problem, currentDepth, noAction)
 
       result match {
         case Success(Solution(_)) | Failure(_) => result
-        case _ if currentDepth == Int.MaxValue => Failure[DLSResult](new Exception("Depth has reached Int.MaxValue"))
-        case _                                 => searchHelper(currentDepth + 1)
+        case _ if currentDepth == Int.MaxValue =>
+          Failure[DLSResult[Action]](new Exception("Depth has reached Int.MaxValue"))
+        case _ => searchHelper(currentDepth + 1)
       }
     }
 

--- a/core/src/main/scala/aima/core/search/uninformed/TreeSearch.scala
+++ b/core/src/main/scala/aima/core/search/uninformed/TreeSearch.scala
@@ -1,6 +1,5 @@
 package aima.core.search.uninformed
 
-import aima.core.agent.Action
 import aima.core.search._
 
 import scala.annotation.tailrec
@@ -8,13 +7,15 @@ import scala.annotation.tailrec
 /**
   * @author Shawn Garner
   */
-trait TreeSearch extends ProblemSearch with FrontierSearch {
-  type Node = StateNode
+trait TreeSearch[State, Action]
+    extends ProblemSearch[State, Action, StateNode[State, Action]]
+    with FrontierSearch[State, Action, StateNode[State, Action]] {
+  type Node = StateNode[State, Action]
 
-  def search(problem: Problem): List[Action] = {
-    val initialFrontier = newFrontier(problem.initialState)
+  def search(problem: Problem[State, Action], noAction: Action): List[Action] = {
+    val initialFrontier = newFrontier(problem.initialState, noAction)
 
-    @tailrec def searchHelper(frontier: Frontier[Node]): List[Action] = {
+    @tailrec def searchHelper(frontier: Frontier[State, Action, Node]): List[Action] = {
       frontier.removeLeaf match {
         case None                                               => List.empty[Action]
         case Some((leaf, _)) if problem.isGoalState(leaf.state) => solution(leaf)

--- a/core/src/main/scala/aima/core/search/uninformed/UniformCostSearch.scala
+++ b/core/src/main/scala/aima/core/search/uninformed/UniformCostSearch.scala
@@ -3,7 +3,6 @@ package aima.core.search.uninformed
 import aima.core.search._
 
 import scala.annotation.tailrec
-import scala.reflect.ClassTag
 
 /**
   * @author Shawn Garner
@@ -11,8 +10,6 @@ import scala.reflect.ClassTag
 trait UniformCostSearch[State, Action]
     extends ProblemSearch[State, Action, CostNode[State, Action]]
     with FrontierSearch[State, Action, CostNode[State, Action]] {
-  implicit val sCT: ClassTag[State]
-  implicit val aCT: ClassTag[Action]
 
   type Node = CostNode[State, Action]
 

--- a/core/src/main/scala/aima/core/search/uninformed/UniformCostSearch.scala
+++ b/core/src/main/scala/aima/core/search/uninformed/UniformCostSearch.scala
@@ -3,6 +3,7 @@ package aima.core.search.uninformed
 import aima.core.search._
 
 import scala.annotation.tailrec
+import scala.reflect.ClassTag
 
 /**
   * @author Shawn Garner
@@ -10,13 +11,13 @@ import scala.annotation.tailrec
 trait UniformCostSearch[State, Action]
     extends ProblemSearch[State, Action, CostNode[State, Action]]
     with FrontierSearch[State, Action, CostNode[State, Action]] {
-
-  val noAction: Action
+  implicit val sCT: ClassTag[State]
+  implicit val aCT: ClassTag[Action]
 
   type Node = CostNode[State, Action]
 
-  def search(problem: Problem[State, Action]): List[Action] = {
-    val initialFrontier = newFrontier(problem.initialState)
+  def search(problem: Problem[State, Action], noAction: Action): List[Action] = {
+    val initialFrontier = newFrontier(problem.initialState, noAction)
 
     @tailrec def searchHelper(
         frontier: Frontier[State, Action, Node],
@@ -50,7 +51,7 @@ trait UniformCostSearch[State, Action]
     searchHelper(initialFrontier)
   }
 
-  def newFrontier(state: State) = {
+  def newFrontier(state: State, noAction: Action) = {
     val costNodeOrdering: Ordering[Node] = new Ordering[Node] {
       def compare(n1: Node, n2: Node): Int = Ordering.Int.reverse.compare(n1.cost, n2.cost)
     }

--- a/core/src/main/scala/aima/core/search/uninformed/UniformCostSearch.scala
+++ b/core/src/main/scala/aima/core/search/uninformed/UniformCostSearch.scala
@@ -1,6 +1,5 @@
 package aima.core.search.uninformed
 
-import aima.core.agent.{NoAction, Action}
 import aima.core.search._
 
 import scala.annotation.tailrec
@@ -8,14 +7,21 @@ import scala.annotation.tailrec
 /**
   * @author Shawn Garner
   */
-trait UniformCostSearch extends ProblemSearch with FrontierSearch {
+trait UniformCostSearch[State, Action]
+    extends ProblemSearch[State, Action, CostNode[State, Action]]
+    with FrontierSearch[State, Action, CostNode[State, Action]] {
 
-  type Node = CostNode
+  val noAction: Action
 
-  def search(problem: Problem): List[Action] = {
+  type Node = CostNode[State, Action]
+
+  def search(problem: Problem[State, Action]): List[Action] = {
     val initialFrontier = newFrontier(problem.initialState)
 
-    @tailrec def searchHelper(frontier: Frontier[Node], exploredSet: Set[State] = Set.empty[State]): List[Action] = {
+    @tailrec def searchHelper(
+        frontier: Frontier[State, Action, Node],
+        exploredSet: Set[State] = Set.empty[State]
+    ): List[Action] = {
       frontier.removeLeaf match {
         case None                                               => List.empty[Action]
         case Some((leaf, _)) if problem.isGoalState(leaf.state) => solution(leaf)
@@ -45,13 +51,13 @@ trait UniformCostSearch extends ProblemSearch with FrontierSearch {
   }
 
   def newFrontier(state: State) = {
-    val costNodeOrdering: Ordering[CostNode] = new Ordering[CostNode] {
-      def compare(n1: CostNode, n2: CostNode): Int = Ordering.Int.reverse.compare(n1.cost, n2.cost)
+    val costNodeOrdering: Ordering[Node] = new Ordering[Node] {
+      def compare(n1: Node, n2: Node): Int = Ordering.Int.reverse.compare(n1.cost, n2.cost)
     }
-    new PriorityQueueHashSetFrontier[CostNode](CostNode(state, 0, NoAction, None), costNodeOrdering)
+    new PriorityQueueHashSetFrontier[State, Action, Node](CostNode(state, 0, noAction, None), costNodeOrdering)
   }
 
-  def newChildNode(problem: Problem, parent: CostNode, action: Action): CostNode = {
+  def newChildNode(problem: Problem[State, Action], parent: Node, action: Action): Node = {
     val childState = problem.result(parent.state, action)
     CostNode(
       state = childState,

--- a/core/src/main/scala/aima/core/search/uninformed/frontier.scala
+++ b/core/src/main/scala/aima/core/search/uninformed/frontier.scala
@@ -1,22 +1,23 @@
 package aima.core.search.uninformed
 
-import aima.core.search.{Frontier, State, SearchNode}
+import aima.core.search.{Frontier, SearchNode}
 
 import scala.collection.immutable.{Queue, Iterable}
 import scala.collection.mutable
 import scala.util.Try
 
-class FIFOQueueFrontier[Node <: SearchNode](queue: Queue[Node], stateSet: Set[State]) extends Frontier[Node] { self =>
+class FIFOQueueFrontier[State, Action, Node <: SearchNode[State, Action]](queue: Queue[Node], stateSet: Set[State])
+    extends Frontier[State, Action, Node] { self =>
   def this(n: Node) = this(Queue(n), Set(n.state))
 
-  def removeLeaf: Option[(Node, Frontier[Node])] = queue.dequeueOption.map {
-    case (leaf, updatedQueue) => (leaf, new FIFOQueueFrontier(updatedQueue, stateSet - leaf.state))
+  def removeLeaf: Option[(Node, Frontier[State, Action, Node])] = queue.dequeueOption.map {
+    case (leaf, updatedQueue) => (leaf, new FIFOQueueFrontier[State, Action, Node](updatedQueue, stateSet - leaf.state))
   }
-  def addAll(iterable: Iterable[Node]): Frontier[Node] =
+  def addAll(iterable: Iterable[Node]): Frontier[State, Action, Node] =
     new FIFOQueueFrontier(queue.enqueue(iterable), stateSet ++ iterable.map(_.state))
   def contains(state: State): Boolean = stateSet.contains(state)
 
-  def replaceByState(node: Node): Frontier[Node] = {
+  def replaceByState(node: Node): Frontier[State, Action, Node] = {
     if (contains(node.state)) {
       new FIFOQueueFrontier(queue.filterNot(_.state == node.state).enqueue(node), stateSet)
     } else {
@@ -31,25 +32,26 @@ class FIFOQueueFrontier[Node <: SearchNode](queue: Queue[Node], stateSet: Set[St
     }
   }
 
-  def add(node: Node): Frontier[Node] = new FIFOQueueFrontier[Node](queue.enqueue(node), stateSet + node.state)
+  def add(node: Node): Frontier[State, Action, Node] =
+    new FIFOQueueFrontier[State, Action, Node](queue.enqueue(node), stateSet + node.state)
 }
 
-class PriorityQueueHashSetFrontier[Node <: SearchNode](
+class PriorityQueueHashSetFrontier[State, Action, Node <: SearchNode[State, Action]](
     queue: mutable.PriorityQueue[Node],
     stateMap: mutable.Map[State, Node]
-) extends Frontier[Node] { self =>
+) extends Frontier[State, Action, Node] { self =>
 
   def this(n: Node, costNodeOrdering: Ordering[Node]) =
     this(mutable.PriorityQueue(n)(costNodeOrdering), mutable.Map(n.state -> n))
 
-  def removeLeaf: Option[(Node, Frontier[Node])] =
+  def removeLeaf: Option[(Node, Frontier[State, Action, Node])] =
     Try {
       val leaf = queue.dequeue
       stateMap -= leaf.state
       (leaf, self)
     }.toOption
 
-  def addAll(iterable: Iterable[Node]): Frontier[Node] = {
+  def addAll(iterable: Iterable[Node]): Frontier[State, Action, Node] = {
     iterable.foreach { costNode =>
       queue += costNode
       stateMap += (costNode.state -> costNode)
@@ -59,7 +61,7 @@ class PriorityQueueHashSetFrontier[Node <: SearchNode](
 
   def contains(state: State): Boolean = stateMap.contains(state)
 
-  def replaceByState(node: Node): Frontier[Node] = {
+  def replaceByState(node: Node): Frontier[State, Action, Node] = {
     if (contains(node.state)) {
       val updatedElems = node :: queue.toList.filterNot(_.state == node.state)
       queue.clear()
@@ -77,7 +79,7 @@ class PriorityQueueHashSetFrontier[Node <: SearchNode](
     }
   }
 
-  def add(node: Node): Frontier[Node] = {
+  def add(node: Node): Frontier[State, Action, Node] = {
     val costNode = node
     queue.enqueue(costNode)
     stateMap += (node.state -> costNode)

--- a/core/src/main/scala/aima/core/util/Randomness.scala
+++ b/core/src/main/scala/aima/core/util/Randomness.scala
@@ -10,7 +10,7 @@ trait Randomness {
 }
 
 trait DefaultRandomness extends Randomness {
-  lazy val rand = new Random()
+  val rand = new Random()
 }
 
 trait EnumerationRandomness extends Randomness { self: Enumeration =>

--- a/core/src/test/scala/aima/core/environment/vacuum/ModelBasedReflexVacuumAgentSpec.scala
+++ b/core/src/test/scala/aima/core/environment/vacuum/ModelBasedReflexVacuumAgentSpec.scala
@@ -1,6 +1,5 @@
 package aima.core.environment.vacuum
 
-import aima.core.agent.{NoPercept, NoAction}
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 

--- a/core/src/test/scala/aima/core/environment/vacuum/TableDrivenVacuumAgentSpec.scala
+++ b/core/src/test/scala/aima/core/environment/vacuum/TableDrivenVacuumAgentSpec.scala
@@ -1,6 +1,5 @@
 package aima.core.environment.vacuum
 
-import aima.core.agent.{Action, NoAction, NoPercept, Percept}
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 
@@ -67,7 +66,7 @@ class TableDrivenVacuumAgentSpec extends Specification {
 
   "table driven agent must persist all percepts" in new context {
     val rnd = new Random()
-    val randomPerceptStream: Stream[Percept] = Stream.continually {
+    val randomPerceptStream: Stream[VacuumPercept] = Stream.continually {
       val selector = rnd.nextInt(3)
       if (selector == 0)
         LocationPercept.randomValue
@@ -86,7 +85,7 @@ class TableDrivenVacuumAgentSpec extends Specification {
 
   trait context extends Scope {
     val agent = new TableDrivenVacuumAgent
-    def invokeAgent(percepts: List[Percept]): List[Action] = {
+    def invokeAgent(percepts: List[VacuumPercept]): List[VacuumAction] = {
       percepts.map(agent.agentFunction)
     }
   }

--- a/core/src/test/scala/aima/core/environment/vacuum/VacuumMapSpec.scala
+++ b/core/src/test/scala/aima/core/environment/vacuum/VacuumMapSpec.scala
@@ -1,6 +1,6 @@
 package aima.core.environment.vacuum
 
-import aima.core.agent.{NoAction, Agent}
+import aima.core.agent.Agent
 import org.scalacheck.Arbitrary
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
@@ -115,13 +115,13 @@ class VacuumMapSpec extends Specification with ScalaCheck {
     map.addAgent(agent).removeAgent(agent) must_== map
   }
 
-  def noopAgent = new Agent {
+  def noopAgent = new Agent[VacuumAction, VacuumPercept] {
     def agentFunction: AgentFunction = { _ =>
       NoAction
     }
   }
 
-  def agentNode(agent: Agent = noopAgent) = VacuumMapNode(maybeAgent = Some(agent))
-  def dirtyNode                           = VacuumMapNode(DirtyPercept, None)
-  def cleanNode                           = VacuumMapNode(CleanPercept, None)
+  def agentNode(agent: Agent[VacuumAction, VacuumPercept] = noopAgent) = VacuumMapNode(maybeAgent = Some(agent))
+  def dirtyNode                                                        = VacuumMapNode(DirtyPercept, None)
+  def cleanNode                                                        = VacuumMapNode(CleanPercept, None)
 }

--- a/core/src/test/scala/aima/core/search/contingency/AndOrGraphSearchSpec.scala
+++ b/core/src/test/scala/aima/core/search/contingency/AndOrGraphSearchSpec.scala
@@ -5,6 +5,8 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 
+import scala.reflect.ClassTag
+
 object AndOrGraphSearchSpec {
   sealed trait Action
   case object MoveLeft  extends Action
@@ -92,6 +94,9 @@ object AndOrGraphSearchSpec {
   */
 class AndOrGraphSearchSpec extends Specification with AndOrGraphSearch[Action, VacuumWorldState] with ScalaCheck {
   import AndOrGraphSearchSpec._
+  import scala.reflect.classTag
+  override implicit val aCT: ClassTag[Action]           = classTag[Action]
+  override implicit val sCT: ClassTag[VacuumWorldState] = classTag[VacuumWorldState]
 
   "AndOrGraphSearch" should {
     "handle State 1 [*_/][* ]" in {

--- a/core/src/test/scala/aima/core/search/contingency/AndOrGraphSearchSpec.scala
+++ b/core/src/test/scala/aima/core/search/contingency/AndOrGraphSearchSpec.scala
@@ -87,6 +87,10 @@ object AndOrGraphSearchSpec {
     override def stepCost(s: VacuumWorldState, a: Action, childPrime: VacuumWorldState): Double =
       ??? // Not used
   }
+
+  import scala.reflect.classTag
+  val aCTag: ClassTag[Action]           = classTag[Action]
+  val sCTag: ClassTag[VacuumWorldState] = classTag[VacuumWorldState]
 }
 
 /**
@@ -94,9 +98,6 @@ object AndOrGraphSearchSpec {
   */
 class AndOrGraphSearchSpec extends Specification with AndOrGraphSearch[Action, VacuumWorldState] with ScalaCheck {
   import AndOrGraphSearchSpec._
-  import scala.reflect.classTag
-  override implicit val aCT: ClassTag[Action]           = classTag[Action]
-  override implicit val sCT: ClassTag[VacuumWorldState] = classTag[VacuumWorldState]
 
   "AndOrGraphSearch" should {
     "handle State 1 [*_/][* ]" in {
@@ -199,4 +200,6 @@ class AndOrGraphSearchSpec extends Specification with AndOrGraphSearch[Action, V
       }
     }
   }
+  override implicit val aCT: ClassTag[Action]           = aCTag
+  override implicit val sCT: ClassTag[VacuumWorldState] = sCTag
 }

--- a/core/src/test/scala/aima/core/search/local/HillClimbingSpec.scala
+++ b/core/src/test/scala/aima/core/search/local/HillClimbingSpec.scala
@@ -1,7 +1,6 @@
 package aima.core.search.local
 
-import aima.core.agent.Action
-import aima.core.search.{Problem, State}
+import aima.core.search.Problem
 import org.scalacheck.{Arbitrary, Gen}
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
@@ -19,15 +18,15 @@ class HillClimbingSpec extends Specification with ScalaCheck {
   }
 
   "must find pi/2 on sin graph between zero and pi" >> prop { xCoord: XCoordinate =>
-    val stateToValue: State => Double = {
+    val stateToValue: XCoordinate => Double = {
       case XCoordinate(x) => math.sin(x)
     }
 
-    val sinProblem = new Problem {
-      override def initialState: State                 = xCoord
-      override def isGoalState(state: State): Boolean  = false // Not used
-      override def actions(state: State): List[Action] = List(StepLeft, StepRight)
-      override def result(state: State, action: Action): State = (state, action) match {
+    val sinProblem = new Problem[XCoordinate, StepAction] {
+      override def initialState: XCoordinate                     = xCoord
+      override def isGoalState(state: XCoordinate): Boolean      = false // Not used
+      override def actions(state: XCoordinate): List[StepAction] = List(StepLeft, StepRight)
+      override def result(state: XCoordinate, action: StepAction): XCoordinate = (state, action) match {
         case (XCoordinate(x), StepLeft) =>
           val newX = x - 0.001d
           if (x < 0) {
@@ -45,7 +44,7 @@ class HillClimbingSpec extends Specification with ScalaCheck {
           }
       }
 
-      override def stepCost(state: State, action: Action, childPrime: State): Int = -1 // Not Used
+      override def stepCost(state: XCoordinate, action: StepAction, childPrime: XCoordinate): Int = -1 // Not Used
     }
 
     val result = HillClimbing(stateToValue)(sinProblem)
@@ -57,8 +56,8 @@ class HillClimbingSpec extends Specification with ScalaCheck {
 }
 
 object HillClimbingSpec {
-  final case class XCoordinate(x: Double) extends State
-  sealed trait StepAction                 extends Action
-  case object StepLeft                    extends StepAction
-  case object StepRight                   extends StepAction
+  final case class XCoordinate(x: Double)
+  sealed trait StepAction
+  case object StepLeft  extends StepAction
+  case object StepRight extends StepAction
 }

--- a/core/src/test/scala/aima/core/search/local/SimulatedAnnealingSearchSpec.scala
+++ b/core/src/test/scala/aima/core/search/local/SimulatedAnnealingSearchSpec.scala
@@ -1,7 +1,6 @@
 package aima.core.search.local
 
-import aima.core.agent.Action
-import aima.core.search.{Problem, State}
+import aima.core.search.Problem
 import aima.core.search.local.SimulatedAnnealingSearch.{
   BasicSchedule,
   OverTimeStepLimit,
@@ -99,12 +98,12 @@ class SimulatedAnnealingSearchSpec extends Specification with ScalaCheck {
     }
 
     "find solution" >> prop { s: EightQueensState =>
-      val eightQueensProblem = new Problem {
-        override def initialState: State = s
+      val eightQueensProblem = new Problem[EightQueensState, EightQueensAction] {
+        override def initialState = s
 
-        override def isGoalState(state: State): Boolean = false // Not used
+        override def isGoalState(state: EightQueensState): Boolean = false // Not used
 
-        override def actions(state: State): List[Action] = state match {
+        override def actions(state: EightQueensState): List[EightQueensAction] = state match {
           case EightQueensState(cols) =>
             cols.zipWithIndex.flatMap {
               case (QueenPosition(rowIndex), colIndex) =>
@@ -112,13 +111,15 @@ class SimulatedAnnealingSearchSpec extends Specification with ScalaCheck {
             }
         }
 
-        override def result(state: State, action: Action): State = (state, action) match {
-          case (EightQueensState(cols), MoveTo(colIndex, newRowIndex)) =>
-            EightQueensState(cols.updated(colIndex, QueenPosition(newRowIndex)))
+        override def result(state: EightQueensState, action: EightQueensAction): EightQueensState =
+          (state, action) match {
+            case (EightQueensState(cols), MoveTo(colIndex, newRowIndex)) =>
+              EightQueensState(cols.updated(colIndex, QueenPosition(newRowIndex)))
 
-        }
+          }
 
-        override def stepCost(state: State, action: Action, childPrime: State): Int = -1 // Not used
+        override def stepCost(state: EightQueensState, action: EightQueensAction, childPrime: EightQueensState): Int =
+          -1 // Not used
       }
 
       val result =
@@ -157,11 +158,11 @@ class SimulatedAnnealingSearchSpec extends Specification with ScalaCheck {
 }
 
 object SimulatedAnnealingSearchSpec {
-  sealed trait QueenMove                                      extends Action
-  final case class MoveTo(columnIndex: Int, newRowIndex: Int) extends QueenMove
+  sealed trait EightQueensAction
+  final case class MoveTo(columnIndex: Int, newRowIndex: Int) extends EightQueensAction
 
-  final case class QueenPosition(row: Int)                        extends AnyVal
-  final case class EightQueensState(columns: List[QueenPosition]) extends State
+  final case class QueenPosition(row: Int) extends AnyVal
+  final case class EightQueensState(columns: List[QueenPosition])
 
   def canAttackHorizontal(columnIndex: Int, s: EightQueensState): Boolean = {
     val currentRow      = s.columns(columnIndex).row
@@ -181,15 +182,15 @@ object SimulatedAnnealingSearchSpec {
     rows.contains(true)
   }
 
-  val queenStateToValue: State => Double = {
+  val queenStateToValue: EightQueensState => Double = {
     case state @ EightQueensState(cols) =>
-      cols.zipWithIndex.foldLeft(0) {
+      cols.zipWithIndex.foldLeft(0.0d) {
         case (acc, elem) =>
           val currentColumnIndex = elem._2
           if (canAttackHorizontal(currentColumnIndex, state) || canAttackDiagonal(currentColumnIndex, state)) {
             acc
           } else {
-            acc + 1
+            acc + 1.0d
           }
 
       }

--- a/core/src/test/scala/aima/core/search/uninformed/RomaniaBreadthFirstSearchSpec.scala
+++ b/core/src/test/scala/aima/core/search/uninformed/RomaniaBreadthFirstSearchSpec.scala
@@ -25,12 +25,10 @@ class RomaniaBreadthFirstSearchSpec extends Specification {
   }
 
   trait context extends Scope with BreadthFirstSearch[RomaniaState, RomaniaAction] {
-    import scala.reflect.classTag
 
-    override implicit val sCT: ClassTag[RomaniaState]  = classTag[RomaniaState]
-    override implicit val aCT: ClassTag[RomaniaAction] = classTag[RomaniaAction]
-    override implicit val nCT: ClassTag[StateNode[RomaniaState, RomaniaAction]] =
-      classTag[StateNode[RomaniaState, RomaniaAction]]
+    override implicit val sCT: ClassTag[RomaniaState]                           = sCTag
+    override implicit val aCT: ClassTag[RomaniaAction]                          = aCTag
+    override implicit val nCT: ClassTag[StateNode[RomaniaState, RomaniaAction]] = snCTag
   }
 
 }

--- a/core/src/test/scala/aima/core/search/uninformed/RomaniaBreadthFirstSearchSpec.scala
+++ b/core/src/test/scala/aima/core/search/uninformed/RomaniaBreadthFirstSearchSpec.scala
@@ -1,8 +1,11 @@
 package aima.core.search.uninformed
 
+import aima.core.search.StateNode
 import aima.core.search.problems.Romania._
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
+
+import scala.reflect.ClassTag
 
 /**
   * @author Shawn Garner
@@ -10,13 +13,24 @@ import org.specs2.specification.Scope
 class RomaniaBreadthFirstSearchSpec extends Specification {
 
   "going from Arad to Arad must return no actions" in new context {
-    search(new RomaniaRoadProblem(In(Arad), In(Arad))) must beEmpty
+    search(new RomaniaRoadProblem(In(Arad), In(Arad)), NoAction) must beEmpty
   }
 
   "going from Arad to Bucharest must return a list of actions" in new context {
-    search(new RomaniaRoadProblem(In(Arad), In(Bucharest))) must_== List(GoTo(Sibiu), GoTo(Fagaras), GoTo(Bucharest))
+    search(new RomaniaRoadProblem(In(Arad), In(Bucharest)), NoAction) must_== List(
+      GoTo(Sibiu),
+      GoTo(Fagaras),
+      GoTo(Bucharest)
+    )
   }
 
-  trait context extends Scope with BreadthFirstSearch {}
+  trait context extends Scope with BreadthFirstSearch[RomaniaState, RomaniaAction] {
+    import scala.reflect.classTag
+
+    override implicit val sCT: ClassTag[RomaniaState]  = classTag[RomaniaState]
+    override implicit val aCT: ClassTag[RomaniaAction] = classTag[RomaniaAction]
+    override implicit val nCT: ClassTag[StateNode[RomaniaState, RomaniaAction]] =
+      classTag[StateNode[RomaniaState, RomaniaAction]]
+  }
 
 }

--- a/core/src/test/scala/aima/core/search/uninformed/RomaniaDepthLimitedTreeSearchSpec.scala
+++ b/core/src/test/scala/aima/core/search/uninformed/RomaniaDepthLimitedTreeSearchSpec.scala
@@ -37,9 +37,7 @@ class RomaniaDepthLimitedTreeSearchSpec extends Specification {
   }
 
   trait context extends Scope with DepthLimitedTreeSearch[RomaniaState, RomaniaAction] {
-    import scala.reflect.classTag
-    override implicit val nCT: ClassTag[StateNode[RomaniaState, RomaniaAction]] =
-      classTag[StateNode[RomaniaState, RomaniaAction]]
+    override implicit val nCT: ClassTag[StateNode[RomaniaState, RomaniaAction]] = snCTag
   }
 
 }

--- a/core/src/test/scala/aima/core/search/uninformed/RomaniaDepthLimitedTreeSearchSpec.scala
+++ b/core/src/test/scala/aima/core/search/uninformed/RomaniaDepthLimitedTreeSearchSpec.scala
@@ -1,9 +1,11 @@
 package aima.core.search.uninformed
 
-import aima.core.agent.Action
+import aima.core.search.StateNode
 import aima.core.search.problems.Romania._
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
+
+import scala.reflect.ClassTag
 
 /**
   * @author Shawn Garner
@@ -11,29 +13,33 @@ import org.specs2.specification.Scope
 class RomaniaDepthLimitedTreeSearchSpec extends Specification {
 
   "going from Arad to Arad must return no actions" in new context {
-    search(new RomaniaRoadProblem(In(Arad), In(Arad)), 1) must beSuccessfulTry.like {
+    search(new RomaniaRoadProblem(In(Arad), In(Arad)), 1, NoAction) must beSuccessfulTry.like {
       case Solution(Nil) => ok
     }
   }
 
   "going from Arad to Bucharest must return a list of actions with depth 19" in new context {
-    search(new RomaniaRoadProblem(In(Arad), In(Bucharest)), 19) must beSuccessfulTry.like {
+    search(new RomaniaRoadProblem(In(Arad), In(Bucharest)), 19, NoAction) must beSuccessfulTry.like {
       case Solution(GoTo(Sibiu) :: GoTo(RimnicuVilcea) :: GoTo(Pitesti) :: GoTo(Bucharest) :: Nil) => ok
     }
   }
 
   "going from Arad to Bucharest must return a list of actions with depth 9" in new context {
-    search(new RomaniaRoadProblem(In(Arad), In(Bucharest)), 9) must beSuccessfulTry.like {
+    search(new RomaniaRoadProblem(In(Arad), In(Bucharest)), 9, NoAction) must beSuccessfulTry.like {
       case Solution(GoTo(Sibiu) :: GoTo(RimnicuVilcea) :: GoTo(Pitesti) :: GoTo(Bucharest) :: Nil) => ok
     }
   }
 
   "going from Arad to Bucharest must return a Cuttoff with depth 1" in new context {
-    search(new RomaniaRoadProblem(In(Arad), In(Bucharest)), 1) must beSuccessfulTry.like {
+    search(new RomaniaRoadProblem(In(Arad), In(Bucharest)), 1, NoAction) must beSuccessfulTry.like {
       case CutOff(GoTo(Zerind) :: Nil) => ok
     }
   }
 
-  trait context extends Scope with DepthLimitedTreeSearch {}
+  trait context extends Scope with DepthLimitedTreeSearch[RomaniaState, RomaniaAction] {
+    import scala.reflect.classTag
+    override implicit val nCT: ClassTag[StateNode[RomaniaState, RomaniaAction]] =
+      classTag[StateNode[RomaniaState, RomaniaAction]]
+  }
 
 }

--- a/core/src/test/scala/aima/core/search/uninformed/RomaniaIterativeDeepeningSearchSpec.scala
+++ b/core/src/test/scala/aima/core/search/uninformed/RomaniaIterativeDeepeningSearchSpec.scala
@@ -1,8 +1,11 @@
 package aima.core.search.uninformed
 
+import aima.core.search.StateNode
 import aima.core.search.problems.Romania._
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
+
+import scala.reflect.ClassTag
 
 /**
   * @author Shawn Garner
@@ -10,20 +13,24 @@ import org.specs2.specification.Scope
 class RomaniaIterativeDeepeningSearchSpec extends Specification {
 
   "going from Arad to Arad must return no actions" in new context {
-    search(new RomaniaRoadProblem(In(Arad), In(Arad))) must beSuccessfulTry.like {
+    search(new RomaniaRoadProblem(In(Arad), In(Arad)), NoAction) must beSuccessfulTry.like {
       case Solution(Nil) => ok
     }
   }
 
   "going from Arad to Bucharest must return a list of actions" in new context {
-    search(new RomaniaRoadProblem(In(Arad), In(Bucharest))) must beSuccessfulTry.like {
+    search(new RomaniaRoadProblem(In(Arad), In(Bucharest)), NoAction) must beSuccessfulTry.like {
       case Solution(GoTo(Sibiu) :: GoTo(Fagaras) :: GoTo(Bucharest) :: Nil) => ok
     }
   }
 
-  trait context extends Scope with IterativeDeepeningSearch {
+  trait context extends Scope with IterativeDeepeningSearch[RomaniaState, RomaniaAction] {
 
-    lazy val depthLimitedTreeSearch = new DepthLimitedTreeSearch {}
+    val depthLimitedTreeSearch = new DepthLimitedTreeSearch[RomaniaState, RomaniaAction] {
+      import scala.reflect.classTag
+      override implicit val nCT: ClassTag[StateNode[RomaniaState, RomaniaAction]] =
+        classTag[StateNode[RomaniaState, RomaniaAction]]
+    }
   }
 
 }

--- a/core/src/test/scala/aima/core/search/uninformed/RomaniaIterativeDeepeningSearchSpec.scala
+++ b/core/src/test/scala/aima/core/search/uninformed/RomaniaIterativeDeepeningSearchSpec.scala
@@ -27,9 +27,7 @@ class RomaniaIterativeDeepeningSearchSpec extends Specification {
   trait context extends Scope with IterativeDeepeningSearch[RomaniaState, RomaniaAction] {
 
     val depthLimitedTreeSearch = new DepthLimitedTreeSearch[RomaniaState, RomaniaAction] {
-      import scala.reflect.classTag
-      override implicit val nCT: ClassTag[StateNode[RomaniaState, RomaniaAction]] =
-        classTag[StateNode[RomaniaState, RomaniaAction]]
+      override implicit val nCT: ClassTag[StateNode[RomaniaState, RomaniaAction]] = snCTag
     }
   }
 

--- a/core/src/test/scala/aima/core/search/uninformed/RomaniaUniformCostSearchSpec.scala
+++ b/core/src/test/scala/aima/core/search/uninformed/RomaniaUniformCostSearchSpec.scala
@@ -1,8 +1,11 @@
 package aima.core.search.uninformed
 
+import aima.core.search.CostNode
 import aima.core.search.problems.Romania._
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
+
+import scala.reflect.ClassTag
 
 /**
   * @author Shawn Garner
@@ -10,11 +13,11 @@ import org.specs2.specification.Scope
 class RomaniaUniformCostSearchSpec extends Specification {
 
   "going from Arad to Arad must return no actions" in new context {
-    search(new RomaniaRoadProblem(In(Arad), In(Arad))) must beEmpty
+    search(new RomaniaRoadProblem(In(Arad), In(Arad)), NoAction) must beEmpty
   }
 
   "going from Arad to Bucharest must return a list of actions" in new context {
-    search(new RomaniaRoadProblem(In(Arad), In(Bucharest))) must_== List(
+    search(new RomaniaRoadProblem(In(Arad), In(Bucharest)), NoAction) must_== List(
       GoTo(Sibiu),
       GoTo(RimnicuVilcea),
       GoTo(Pitesti),
@@ -22,6 +25,10 @@ class RomaniaUniformCostSearchSpec extends Specification {
     )
   }
 
-  trait context extends Scope with UniformCostSearch {}
+  abstract class context extends Scope with UniformCostSearch[RomaniaState, RomaniaAction] {
+    import scala.reflect.classTag
+    override implicit val nCT: ClassTag[CostNode[RomaniaState, RomaniaAction]] =
+      classTag[CostNode[RomaniaState, RomaniaAction]]
+  }
 
 }

--- a/core/src/test/scala/aima/core/search/uninformed/RomaniaUniformCostSearchSpec.scala
+++ b/core/src/test/scala/aima/core/search/uninformed/RomaniaUniformCostSearchSpec.scala
@@ -25,10 +25,8 @@ class RomaniaUniformCostSearchSpec extends Specification {
     )
   }
 
-  abstract class context extends Scope with UniformCostSearch[RomaniaState, RomaniaAction] {
-    import scala.reflect.classTag
-    override implicit val nCT: ClassTag[CostNode[RomaniaState, RomaniaAction]] =
-      classTag[CostNode[RomaniaState, RomaniaAction]]
+  trait context extends Scope with UniformCostSearch[RomaniaState, RomaniaAction] {
+    override implicit val nCT: ClassTag[CostNode[RomaniaState, RomaniaAction]] = cnCTag
   }
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.6")


### PR DESCRIPTION
getting a lot of warnings around sealed traits since using a global one.
this adds compiler settings for completeness and gets rid of global traits for Action, Percept, State, etc.
Also gets rid of some partial functions.
Still some work to get rid of vars and abstract vals.